### PR TITLE
Fix toast hook listener duplication

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -179,7 +179,9 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+    // We only want to register the listener once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent duplicate listeners in `useToast` by running effect only once

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fdd0c64f4832a9900daadf559c01a