### PR TITLE
fix: rename AWS environment variables with EZLIFT_ prefix to avoid Ne…

### DIFF
--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -24,10 +24,10 @@ jobs:
             "CONTENTFUL_SPACE_ID"
             "CONTENTFUL_ACCESS_TOKEN"
             "DATABASE_URL"
-            "AWS_ACCESS_KEY_ID"
-            "AWS_SECRET_ACCESS_KEY"
-            "AWS_REGION"
-            "AWS_S3_BUCKET_NAME"
+            "EZLIFT_EZLIFT_AWS_ACCESS_KEY_ID"
+            "EZLIFT_EZLIFT_AWS_SECRET_ACCESS_KEY"
+            "EZLIFT_EZLIFT_AWS_REGION"
+            "EZLIFT_EZLIFT_AWS_S3_BUCKET_NAME"
           )
           
           # Track missing secrets
@@ -62,10 +62,10 @@ jobs:
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
           CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
+          EZLIFT_AWS_ACCESS_KEY_ID: ${{ secrets.EZLIFT_AWS_ACCESS_KEY_ID }}
+          EZLIFT_AWS_SECRET_ACCESS_KEY: ${{ secrets.EZLIFT_AWS_SECRET_ACCESS_KEY }}
+          EZLIFT_AWS_REGION: ${{ secrets.EZLIFT_AWS_REGION }}
+          EZLIFT_AWS_S3_BUCKET_NAME: ${{ secrets.EZLIFT_AWS_S3_BUCKET_NAME }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
@@ -90,8 +90,8 @@ jobs:
           fi
           
           # Validate AWS region format
-          if [[ ! "$AWS_REGION" =~ ^[a-z0-9-]+$ ]]; then
-            echo "⚠️  Warning: AWS_REGION format seems incorrect"
+          if [[ ! "$EZLIFT_EZLIFT_AWS_REGION" =~ ^[a-z0-9-]+$ ]]; then
+            echo "⚠️  Warning: EZLIFT_EZLIFT_AWS_REGION format seems incorrect"
           fi
           
           # Check if DATABASE_URL starts with expected protocol
@@ -102,7 +102,7 @@ jobs:
           echo "Secret validation completed!"
         env:
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          EZLIFT_EZLIFT_AWS_REGION: ${{ secrets.EZLIFT_EZLIFT_AWS_REGION }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
       - name: Build project
@@ -111,10 +111,10 @@ jobs:
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
           CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
+          EZLIFT_AWS_ACCESS_KEY_ID: ${{ secrets.EZLIFT_AWS_ACCESS_KEY_ID }}
+          EZLIFT_AWS_SECRET_ACCESS_KEY: ${{ secrets.EZLIFT_AWS_SECRET_ACCESS_KEY }}
+          EZLIFT_AWS_REGION: ${{ secrets.EZLIFT_AWS_REGION }}
+          EZLIFT_AWS_S3_BUCKET_NAME: ${{ secrets.EZLIFT_AWS_S3_BUCKET_NAME }}
 
       - name: Debug built files
         run: |
@@ -132,11 +132,11 @@ jobs:
               echo "❌ CONTENTFUL_SPACE_ID not found in built files"
             fi
             
-            echo "Checking for AWS_REGION presence..."
-            if grep -r "AWS_REGION" ./out/ >/dev/null 2>&1; then
-              echo "✅ AWS_REGION found in built files"
+            echo "Checking for EZLIFT_EZLIFT_AWS_REGION presence..."
+            if grep -r "EZLIFT_EZLIFT_AWS_REGION" ./out/ >/dev/null 2>&1; then
+              echo "✅ EZLIFT_EZLIFT_AWS_REGION found in built files"
             else
-              echo "❌ AWS_REGION not found in built files"
+              echo "❌ EZLIFT_EZLIFT_AWS_REGION not found in built files"
             fi
             
             echo "Built files structure:"

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,7 @@ temp-*.js
 temp-*.ts
 *.tmp
 *.temp
+
+# Documentation files
+ENVIRONMENT_SETUP.md
 app/sitemap.xml

--- a/lib/config/environment.ts
+++ b/lib/config/environment.ts
@@ -8,10 +8,10 @@
  * - DATABASE_URL: PostgreSQL connection string
  * 
  * Optional environment variables:
- * - AWS_ACCESS_KEY_ID: AWS access key (for S3 media)
- * - AWS_SECRET_ACCESS_KEY: AWS secret key (for S3 media)
- * - AWS_REGION: AWS region (e.g., us-east-1)
- * - AWS_S3_BUCKET_NAME: S3 bucket for exercise media (images and videos)
+ * - EZLIFT_AWS_ACCESS_KEY_ID: AWS access key (for S3 media)
+ * - EZLIFT_AWS_SECRET_ACCESS_KEY: AWS secret key (for S3 media)
+ * - EZLIFT_AWS_REGION: AWS region (e.g., us-east-1)
+ * - EZLIFT_AWS_S3_BUCKET_NAME: S3 bucket for exercise media (images and videos)
  * - CONTENTFUL_SPACE_ID: Contentful space ID (for rich content)
  * - CONTENTFUL_ACCESS_TOKEN: Contentful access token (for rich content)
  * - CONTENTFUL_ENVIRONMENT: Contentful environment (default: master)
@@ -35,11 +35,11 @@ export const config = {
     url: getEnvVar('DATABASE_URL'),
   },
   aws: {
-    accessKeyId: getEnvVar('AWS_ACCESS_KEY_ID'),
-    secretAccessKey: getEnvVar('AWS_SECRET_ACCESS_KEY'),
-    region: getEnvVar('AWS_REGION', 'us-east-1'),
+    accessKeyId: getEnvVar('EZLIFT_AWS_ACCESS_KEY_ID'),
+    secretAccessKey: getEnvVar('EZLIFT_AWS_SECRET_ACCESS_KEY'),
+    region: getEnvVar('EZLIFT_AWS_REGION', 'us-east-1'),
     s3: {
-      bucketName: getEnvVar('AWS_S3_BUCKET_NAME'),
+      bucketName: getEnvVar('EZLIFT_AWS_S3_BUCKET_NAME'),
       // Legacy support for separate buckets (deprecated)
       bucketImages: getEnvVar('AWS_S3_BUCKET_IMAGES'),
       bucketVideos: getEnvVar('AWS_S3_BUCKET_VIDEOS'),


### PR DESCRIPTION
…tlify reserved keywords

- Rename AWS_ACCESS_KEY_ID to EZLIFT_AWS_ACCESS_KEY_ID
- Rename AWS_SECRET_ACCESS_KEY to EZLIFT_AWS_SECRET_ACCESS_KEY
- Rename AWS_REGION to EZLIFT_AWS_REGION
- Rename AWS_S3_BUCKET_NAME to EZLIFT_AWS_S3_BUCKET_NAME

Updated files:
- lib/config/environment.ts: Updated getEnvVar calls for AWS credentials
- .github/workflows/netlify-deploy.yml: Updated all secret references and validation
- .env.local: Updated local development environment variables
- ENVIRONMENT_SETUP.md: Added comprehensive documentation
- .gitignore: Added ENVIRONMENT_SETUP.md to ignored files

This resolves Netlify deployment conflicts where AWS_* variables are reserved keywords.